### PR TITLE
Add namespace to android build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,6 +25,8 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    // AGP 7.0+ requires namespace declaration, keep it consistent with package name
+    namespace 'com.namit.presentation_displays'
     compileSdkVersion 33
 
     sourceSets {


### PR DESCRIPTION
Declared the 'namespace' property in the android block as required by AGP 7.0+ to ensure consistency with the package name and compatibility with newer Android Gradle Plugin versions.